### PR TITLE
Podspec for Rye

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Rye allows you to present non intrusive alerts to your users of both "Toast" and "Snack Bar" types.
 You can choose to display the default Rye alert type or go fully custom and display your own `UIView`.
 
-### Examples 
+### Examples
 
 
 | ![](ExampleImages/example1.png) | ![](ExampleImages/example2.png)  | ![](ExampleImages/example3.png)  |
@@ -29,15 +29,20 @@ Swift 5
 github "nodes-ios/Rye"
 ~~~
 
+### Cocoapods
+~~~bash
+pod 'nodes-ios/Rye'
+~~~
+
 ## 💻 Usage
 
-```swift 
+```swift
 import Rye
 ```
 
 ### Display Default Rye
 
-```swift 
+```swift
 
 let ryeConfiguration: RyeConfiguration = [Rye.Configuration.Key.text: "Message for the user"]
 
@@ -51,7 +56,7 @@ rye.show()
 
 ### Display Default Rye with Custom Configuration
 
-```swift 
+```swift
 
 let ryeConfiguration: RyeConfiguration = [
     Rye.Configuration.Key.text: "Error message for the user",
@@ -69,7 +74,7 @@ rye.show()
 
 ### Display Rye with a Custom `UIView`
 
-```swift 
+```swift
 
 let customRyeView = RyeView()
 
@@ -83,21 +88,21 @@ rye.show()
 
 ### Alert Type
 
-Rye allows you to define the alert type you want to display to your user. Possible alert types are: 
+Rye allows you to define the alert type you want to display to your user. Possible alert types are:
 
 - snackBar which is displayed at applications UIWindow level and allows interaction with the presented UIView
 - toast which is displayed at applications alert UIWindow level and doesn't allows interaction with the presented UIView
 
-###  Position 
+###  Position
 
-With Rye you can specify the position where the Rye view will be displayed on screen via the `position` parameter, which takes an associated value that allows you to specify the inset. 
+With Rye you can specify the position where the Rye view will be displayed on screen via the `position` parameter, which takes an associated value that allows you to specify the inset.
 By default Rye will calculate the safe area insets for you, so be sure to specify only the extra desired inset.
 
 If you decide to not provide a value for this parameter, you will be in charge of dismissing the Rye when you think it is appropriate.
 
-### Time Used 
+### Time Used
 
-When creating an instance of  `RyeViewController` you can choose to provide a value for  the `timeAlive` parameter during initialisation. The value provided will be the time in seconds the Rye view will be presented on screen to the user. 
+When creating an instance of  `RyeViewController` you can choose to provide a value for  the `timeAlive` parameter during initialisation. The value provided will be the time in seconds the Rye view will be presented on screen to the user.
 
 ### Possible Rye Configurations
 

--- a/Rye.podspec
+++ b/Rye.podspec
@@ -1,0 +1,24 @@
+# coding: utf-8
+
+Pod::Spec.new do |spec|
+
+  spec.name         = "Rye"
+  spec.version      = "1.1.9"
+  spec.summary      = "Rye allows you to present non intrusive alerts to your users of both \"Toast\" and \"Snack Bar\" types. You can choose to display the default Rye alert type or go fully custom and display your own UIView."
+  spec.homepage     = "https://github.com/nodes-ios/Rye"
+
+  spec.author       = { 'Name' => 'kjoneandrei' }
+  spec.license      = { :type => 'MIT', :file => './LICENSE' }
+
+  spec.platform     = :ios
+  spec.source       = { :git => "https://github.com/nodes-ios/Rye.git", :tag => "#{spec.version}" }
+
+  spec.ios.deployment_target = '11'
+  spec.ios.vendored_frameworks = 'Rye.framework'
+
+  spec.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.1' }
+
+  spec.subspec 'Rye' do |subspec|
+    subspec.ios.source_files = 'Rye/Rye/**/*.swift'
+  end
+end

--- a/Rye.podspec
+++ b/Rye.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.summary      = "Rye allows you to present non intrusive alerts to your users of both \"Toast\" and \"Snack Bar\" types. You can choose to display the default Rye alert type or go fully custom and display your own UIView."
   spec.homepage     = "https://github.com/nodes-ios/Rye"
 
-  spec.author       = { 'Name' => 'kjoneandrei' }
+  spec.author       = { "Nodes Agency - iOS" => "ios@nodes.dk" }
   spec.license      = { :type => 'MIT', :file => './LICENSE' }
 
   spec.platform     = :ios


### PR DESCRIPTION
Addresses: https://github.com/nodes-ios/Rye/issues/4

Had to set version to 1.1.9. A new release will have to be done so the podspec will be apart of it and it can be installed at that version.

Tested by importing pod into sample project and imported a Rye.AlertType.snackBar object.