### PR TITLE
Added snackbar support for iOS 13 scene delegates

### DIFF
--- a/Rye/Rye/RyeViewController.swift
+++ b/Rye/Rye/RyeViewController.swift
@@ -38,12 +38,14 @@ public class RyeViewController: UIViewController {
 
                 return topController.view
 
-            } else if #available(iOS 13.0, *) {
-                if var windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            } else if #available(iOS 13.0, *),
+                var windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                     var topController = windowScene.windows[0].rootViewController {
                     while let presentedViewController = topController.presentedViewController {
                         topController = presentedViewController
                     }
+
+                return topController.view
                 }
             } else {
                 assertionFailure("Could not find the top ViewController")

--- a/Rye/Rye/RyeViewController.swift
+++ b/Rye/Rye/RyeViewController.swift
@@ -46,7 +46,7 @@ public class RyeViewController: UIViewController {
                     }
 
                 return topController.view
-                }
+                
             } else {
                 assertionFailure("Could not find the top ViewController")
                 return UIView()

--- a/Rye/Rye/RyeViewController.swift
+++ b/Rye/Rye/RyeViewController.swift
@@ -37,6 +37,11 @@ public class RyeViewController: UIViewController {
                 }
 
                 return topController.view
+            } else if var windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                var topController = windowScene.windows[0].rootViewController {
+                while let presentedViewController = topController.presentedViewController {
+                    topController = presentedViewController
+                }
             } else {
                 assertionFailure("Could not find the top ViewController")
                 return UIView()

--- a/Rye/Rye/RyeViewController.swift
+++ b/Rye/Rye/RyeViewController.swift
@@ -37,10 +37,13 @@ public class RyeViewController: UIViewController {
                 }
 
                 return topController.view
-            } else if var windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                var topController = windowScene.windows[0].rootViewController {
-                while let presentedViewController = topController.presentedViewController {
-                    topController = presentedViewController
+
+            } else if #available(iOS 13.0, *) {
+                if var windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                    var topController = windowScene.windows[0].rootViewController {
+                    while let presentedViewController = topController.presentedViewController {
+                        topController = presentedViewController
+                    }
                 }
             } else {
                 assertionFailure("Could not find the top ViewController")


### PR DESCRIPTION
When using `.snackbar` Rye type in an iOS 13 app that uses a scene delegate, the top controller is unable to be found. This PR adds iOS 13-specific code to find the top controller via the `UIWindowScene`.

I'm not sure if this is the best way to find the top controller, but it works well in my project. I also bumped the tags a few times as I was testing this via SPM in a project where I'm using Rye. Feel free to dump this PR if either of these things make it non-mergeable!