### PR TITLE
Fix for new window creation not working with UISceneDelegate

### DIFF
--- a/Rye/Rye/RyePresentation.swift
+++ b/Rye/Rye/RyePresentation.swift
@@ -16,14 +16,28 @@ public extension RyeViewController {
         switch self.alertType {
         case .toast:
             // create a new UIWindow
-            let window = UIWindow(frame: UIScreen.main.bounds)
-            
-            window.windowLevel = .alert
-            window.rootViewController = self
-            window.backgroundColor = .clear
-            window.makeKeyAndVisible()
+            var window: UIWindow?
+
+            if #available(iOS 13.0, *) {
+                let windowScene = UIApplication.shared
+                    .connectedScenes
+                    .filter { $0.activationState == .foregroundActive }
+                    .first
+                if let windowScene = windowScene as? UIWindowScene {
+                    window = UIWindow(windowScene: windowScene)
+                }
+            } else {
+
+                window = UIWindow(frame: UIScreen.main.bounds)
+
+                window!.windowLevel = .alert
+                window!.rootViewController = self
+                window!.backgroundColor = .clear
+                window!.makeKeyAndVisible()
+            }
             
             self.window = window
+
         case .snackBar:
             break
         }

--- a/Rye/Rye/RyeViewController.swift
+++ b/Rye/Rye/RyeViewController.swift
@@ -39,7 +39,7 @@ public class RyeViewController: UIViewController {
                 return topController.view
 
             } else if #available(iOS 13.0, *),
-                var windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                     var topController = windowScene.windows[0].rootViewController {
                     while let presentedViewController = topController.presentedViewController {
                         topController = presentedViewController


### PR DESCRIPTION
I noticed in my iOS-13 app that uses a `UISceneDelegate`, my `Rye` was never showing up. It seems to be because creating a new window for a toast doesn't work when there's a scene delegate. This commit adds window creation that takes into account the scene delegate for iOS-13 projects.