### PR TITLE
Add insets and use in example app

### DIFF
--- a/Rye/Rye/RyeDefaultView.swift
+++ b/Rye/Rye/RyeDefaultView.swift
@@ -25,9 +25,12 @@ class RyeDefaultView: UIView {
         layer.cornerRadius = (configuration?[.cornerRadius] as? CGFloat) ?? 8
         backgroundColor = (configuration?[.backgroundColor] as? UIColor) ?? UIColor.black.withAlphaComponent(0.4)
         
-        makeMessageLabel(with: (configuration?[.text] as? String) ?? "Add a message",
-                         font: (configuration?[.textFont] as? UIFont) ?? UIFont.systemFont(ofSize: 14, weight: .semibold),
-                         textColor: (configuration?[.textColor] as? UIColor) ?? .white)
+        makeMessageLabel(
+            with: (configuration?[.text] as? String) ?? "Add a message",
+            font: (configuration?[.textFont] as? UIFont) ?? UIFont.systemFont(ofSize: 14, weight: .semibold),
+            textColor: (configuration?[.textColor] as? UIColor) ?? .white,
+            insets: (configuration?[.insets] as? UIEdgeInsets) ?? .zero
+        )
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -36,8 +39,9 @@ class RyeDefaultView: UIView {
     
     // MARK: - Make Subview
     
-    private func makeMessageLabel(with text: String, font: UIFont, textColor: UIColor) {
-        label = UILabel()
+    private func makeMessageLabel(with text: String, font: UIFont, textColor: UIColor, insets: UIEdgeInsets) {
+        let label = InsetLabel()
+        label.contentInsets = insets
         label.numberOfLines = 0
         label.textAlignment = .center
         label.text = text
@@ -50,5 +54,31 @@ class RyeDefaultView: UIView {
         label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16).isActive = true
         label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8).isActive = true
         label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16).isActive = true
+        self.label = label
     }
+}
+
+private class InsetLabel: UILabel {
+    
+    var contentInsets = UIEdgeInsets.zero
+    
+    override func drawText(in rect: CGRect) {
+        let insetRect = rect.inset(by: contentInsets)
+        super.drawText(in: insetRect)
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        return addInsets(to: super.intrinsicContentSize)
+    }
+    
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        return addInsets(to: super.sizeThatFits(size))
+    }
+    
+    private func addInsets(to size: CGSize) -> CGSize {
+        let width = size.width + contentInsets.left + contentInsets.right
+        let height = size.height + contentInsets.top + contentInsets.bottom
+        return CGSize(width: width, height: height)
+    }
+    
 }

--- a/Rye/Rye/RyeType+Configuration.swift
+++ b/Rye/Rye/RyeType+Configuration.swift
@@ -79,6 +79,10 @@ public struct Rye {
              RyeView's animation duration
              */
             case animationDuration
+            /**
+            RyeView's insets
+            */
+            case insets
         }
     }
     

--- a/Rye/RyeExample/Base.lproj/Main.storyboard
+++ b/Rye/RyeExample/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -68,10 +68,42 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="Insets" id="ajm-oy-ijE" userLabel="text">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="x8v-9X-Zkc">
+                                        <rect key="frame" x="0.0" y="373.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="x8v-9X-Zkc" id="keP-ZO-SKV">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="p9S-cJ-7az">
+                                                    <rect key="frame" x="16" y="6" width="94" height="32"/>
+                                                    <connections>
+                                                        <action selector="uniformInsetsChanged:" destination="jYf-jg-epa" eventType="valueChanged" id="HyJ-sH-jJ0"/>
+                                                    </connections>
+                                                </stepper>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a1M-uU-5aD">
+                                                    <rect key="frame" x="356" y="11.5" width="42" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="p9S-cJ-7az" firstAttribute="leading" secondItem="keP-ZO-SKV" secondAttribute="leading" constant="16" id="agN-jJ-MU6"/>
+                                                <constraint firstItem="a1M-uU-5aD" firstAttribute="centerY" secondItem="keP-ZO-SKV" secondAttribute="centerY" id="lge-2Y-gFM"/>
+                                                <constraint firstItem="p9S-cJ-7az" firstAttribute="centerY" secondItem="keP-ZO-SKV" secondAttribute="centerY" id="tLd-U3-Owc"/>
+                                                <constraint firstAttribute="trailing" secondItem="a1M-uU-5aD" secondAttribute="trailing" constant="16" id="zlE-O4-0TJ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="dismissMode" id="5L7-vb-qIw" userLabel="dismissMode">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="dismissAutomatic" textLabel="ZHY-7y-Xdc" style="IBUITableViewCellStyleDefault" id="GyR-V3-SrM">
-                                        <rect key="frame" x="0.0" y="373.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="473" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GyR-V3-SrM" id="3Zh-PE-bRB">
                                             <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
@@ -88,7 +120,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="dismissGesture" textLabel="Vc1-ix-1x4" style="IBUITableViewCellStyleDefault" id="Vvy-91-nG7">
-                                        <rect key="frame" x="0.0" y="417" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="516.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Vvy-91-nG7" id="wNE-Be-sWo">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -105,7 +137,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="dismissNonDismissable" textLabel="6fl-u1-goV" style="IBUITableViewCellStyleDefault" id="4Ie-Fc-Ji7">
-                                        <rect key="frame" x="0.0" y="460.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="560" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4Ie-Fc-Ji7" id="XQL-RV-60W">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -126,7 +158,7 @@
                             <tableViewSection headerTitle="viewType" id="PN3-e8-m9y" userLabel="viewType">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" textLabel="rET-3b-JzA" style="IBUITableViewCellStyleDefault" id="aPp-Fd-b0n">
-                                        <rect key="frame" x="0.0" y="560" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="659.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aPp-Fd-b0n" id="VCU-YQ-0af">
                                             <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
@@ -143,7 +175,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="zbN-OI-SI6" style="IBUITableViewCellStyleDefault" id="dQB-ZN-HOu">
-                                        <rect key="frame" x="0.0" y="603.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="703" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dQB-ZN-HOu" id="5Zu-zP-VGr">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -164,7 +196,7 @@
                             <tableViewSection headerTitle="position" id="I1h-rp-jgL" userLabel="position">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" textLabel="KcJ-TM-OWI" style="IBUITableViewCellStyleDefault" id="14G-FV-aDp">
-                                        <rect key="frame" x="0.0" y="703" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="802.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="14G-FV-aDp" id="gYt-tI-z5R">
                                             <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
@@ -181,7 +213,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="eIS-SC-g15" style="IBUITableViewCellStyleDefault" id="3Fg-Wy-1k3">
-                                        <rect key="frame" x="0.0" y="746.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="846" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3Fg-Wy-1k3" id="tyi-cQ-RzH">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -202,7 +234,7 @@
                             <tableViewSection headerTitle="animationType" id="EPo-mD-Dnl" userLabel="animationType">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" textLabel="PyB-C1-00l" style="IBUITableViewCellStyleDefault" id="YEp-gs-BKj">
-                                        <rect key="frame" x="0.0" y="846" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="945.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YEp-gs-BKj" id="cSS-ZV-9iN">
                                             <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
@@ -219,7 +251,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="FC2-AZ-Cl3" style="IBUITableViewCellStyleDefault" id="bmB-qe-XdO">
-                                        <rect key="frame" x="0.0" y="889.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="989" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bmB-qe-XdO" id="e4u-xL-kJR">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -240,7 +272,7 @@
                             <tableViewSection headerTitle="show me" id="4EL-du-N8D" userLabel="show me">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="100" id="Kf2-TO-aQ3">
-                                        <rect key="frame" x="0.0" y="989" width="414" height="100"/>
+                                        <rect key="frame" x="0.0" y="1088.5" width="414" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Kf2-TO-aQ3" id="7rl-MQ-nqH">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
@@ -285,6 +317,8 @@
                     <connections>
                         <outlet property="dismissRyeButton" destination="8ou-wz-e3Y" id="2hk-fM-o5R"/>
                         <outlet property="generateMessageButton" destination="4xz-C0-gCX" id="dyi-Jl-lPO"/>
+                        <outlet property="insetStepper" destination="p9S-cJ-7az" id="Nt1-D5-l53"/>
+                        <outlet property="insetsLabel" destination="a1M-uU-5aD" id="zc4-CJ-fK8"/>
                         <outlet property="ryeMessageTextField" destination="Yfv-08-rut" id="XYm-Pa-JLZ"/>
                     </connections>
                 </tableViewController>

--- a/Rye/RyeExample/Base.lproj/Main.storyboard
+++ b/Rye/RyeExample/Base.lproj/Main.storyboard
@@ -27,7 +27,7 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lf7-96-9iy">
                                                     <rect key="frame" x="16" y="16" width="382" height="158"/>
-                                                    <string key="text">This sandbox app shows you how the various settings of a Rye view affects how it is displayed. To change the dismissInterval and the contentInset, please update their values directly in the RyeDemoViewController.swift file.</string>
+                                                    <string key="text">This sandbox app shows you how the various settings of a Rye view affects how it is displayed. To change the dismissInterval please update the values directly in the RyeDemoViewController.swift file.</string>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -91,6 +91,7 @@
                                                 </label>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="a1M-uU-5aD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="p9S-cJ-7az" secondAttribute="trailing" constant="16" id="H4q-cp-lfd"/>
                                                 <constraint firstItem="p9S-cJ-7az" firstAttribute="leading" secondItem="keP-ZO-SKV" secondAttribute="leading" constant="16" id="agN-jJ-MU6"/>
                                                 <constraint firstItem="a1M-uU-5aD" firstAttribute="centerY" secondItem="keP-ZO-SKV" secondAttribute="centerY" id="lge-2Y-gFM"/>
                                                 <constraint firstItem="p9S-cJ-7az" firstAttribute="centerY" secondItem="keP-ZO-SKV" secondAttribute="centerY" id="tLd-U3-Owc"/>

--- a/Rye/RyeExample/Rye VC/RyeDemoViewController.swift
+++ b/Rye/RyeExample/Rye VC/RyeDemoViewController.swift
@@ -11,6 +11,18 @@ import Rye
 
 class RyeDemoViewController: UITableViewController {
     
+    enum Section: Int {
+        case introduction
+        case text
+        case insets
+        case dismissMode
+        case viewType
+        case position
+        case animationtype
+    }
+    
+    @IBOutlet weak var insetStepper: UIStepper!
+    @IBOutlet weak var insetsLabel: UILabel!
     // MARK: - Outlets
     @IBOutlet weak var ryeMessageTextField: UITextField!
     @IBOutlet weak var dismissRyeButton: UIButton!
@@ -25,30 +37,35 @@ class RyeDemoViewController: UITableViewController {
     var viewType: Rye.ViewType = .standard(configuration: nil)
     var position: Rye.Position = .top(inset: 20.0)
     var animationType: Rye.AnimationType = .slideInOut
+    var uniformInset: CGFloat = 0 {
+        didSet {
+            insetsLabel.text = "\(uniformInset)"
+        }
+    }
     let customView = RyeImageView.fromNib()
     
     // MARK: - Lifecycle methods
     override func viewDidLoad() {
         super.viewDidLoad()
+        uniformInset = { uniformInset }()
         tableView.tableFooterView = UIView()
         dismissRyeButton.isHidden = true
     }
     
     // MARK: - TableView methods
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        switch indexPath.section {
-        case 0, 1:
+        switch Section(rawValue: indexPath.section)! {
+        case .introduction, .insets, .text:
             break
-        case 2:
+        case .dismissMode:
             updateDismissMode(for: indexPath)
-        case 3:
+        case .viewType:
             updateViewMode(for: indexPath)
-        case 4:
+        case .position:
             updatePosition(for: indexPath)
-        case 5:
+        case .animationtype:
             updateAnimationType(for: indexPath)
-        default:
-            break
+       
         }
     }
     
@@ -114,6 +131,10 @@ class RyeDemoViewController: UITableViewController {
             break
         }
     }
+    @IBAction func uniformInsetsChanged(_ sender: UIStepper) {
+        
+        self.uniformInset = CGFloat(sender.value)
+    }
     
     // MARK: - IBActions
     @IBAction func didTapGenerateMessage(_ sender: UIButton) {
@@ -122,6 +143,7 @@ class RyeDemoViewController: UITableViewController {
 
         if case Rye.ViewType.standard = viewType {
             let ryeConfiguration: RyeConfiguration = [
+                .insets: UIEdgeInsets.init(top: uniformInset, left: uniformInset, bottom: uniformInset, right: uniformInset),
                 .text : ryeMessageTextField.text ?? "",
                 .backgroundColor: UIColor.black.withAlphaComponent(0.5),
                 .animationType: animationType,


### PR DESCRIPTION
This adds the ability to add insets to the standard Rye.. Alternate naming for the .insets key could be .padding

<img width="399" alt="image" src="https://user-images.githubusercontent.com/8362263/82224813-9ff92880-9924-11ea-9dc1-baf768850187.png">
